### PR TITLE
Code cleanup

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataService.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.knowm.xchange.bitfinex.BitfinexErrorAdapter;
 import org.knowm.xchange.bitfinex.BitfinexExchange;
@@ -23,9 +22,7 @@ import org.knowm.xchange.dto.marketdata.LoanOrderBook;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
-import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
 import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
@@ -282,13 +279,23 @@ public class BitfinexMarketDataService extends BitfinexMarketDataServiceRaw
   }
 
 
-  @Override
-  public Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
-      return exchange.getExchangeMetaData().getCurrencies();
+  public List<Currency> getCurrencies() throws IOException {
+    try {
+      return allCurrencies();
+
+    } catch (BitfinexException e) {
+      throw BitfinexErrorAdapter.adapt(e);
+    }
   }
 
-  @Override
-  public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
-    return exchange.getExchangeMetaData().getInstruments();
+  public List<Instrument> getInstruments() throws IOException {
+    try {
+
+      return allCurrencyPairs().stream()
+          .map(Instrument.class::cast)
+          .collect(Collectors.toList());
+    } catch (BitfinexException e) {
+      throw BitfinexErrorAdapter.adapt(e);
+    }
   }
 }

--- a/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataServiceIntegration.java
+++ b/xchange-bitfinex/src/test/java/org/knowm/xchange/bitfinex/service/BitfinexMarketDataServiceIntegration.java
@@ -12,6 +12,7 @@ import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
+import org.knowm.xchange.instrument.Instrument;
 
 public class BitfinexMarketDataServiceIntegration extends BitfinexIntegrationTestParent {
 
@@ -22,8 +23,8 @@ public class BitfinexMarketDataServiceIntegration extends BitfinexIntegrationTes
 
   @Test
   void valid_currencies() throws IOException {
-    var currencies =
-        ((BitfinexMarketDataService) exchange.getMarketDataService()).getCurrencies().keySet();
+    List<Currency> currencies =
+        ((BitfinexMarketDataService) exchange.getMarketDataService()).getCurrencies();
 
     assertThat(currencies).isNotEmpty();
     assertThat(currencies).contains(Currency.BTC, Currency.ETH, Currency.USDT);
@@ -31,8 +32,8 @@ public class BitfinexMarketDataServiceIntegration extends BitfinexIntegrationTes
 
   @Test
   void valid_instruments() throws IOException {
-    var instruments =
-        ((BitfinexMarketDataService) exchange.getMarketDataService()).getInstruments().keySet();
+    List<Instrument> instruments =
+        ((BitfinexMarketDataService) exchange.getMarketDataService()).getInstruments();
 
     assertThat(instruments).isNotEmpty();
     assertThat(instruments).contains(CurrencyPair.BTC_USDT, CurrencyPair.ETH_USDT);

--- a/xchange-bitget/src/main/java/org/knowm/xchange/bitget/service/BitgetMarketDataService.java
+++ b/xchange-bitget/src/main/java/org/knowm/xchange/bitget/service/BitgetMarketDataService.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.knowm.xchange.bitget.BitgetAdapters;
@@ -20,9 +19,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
-import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 import org.knowm.xchange.service.marketdata.params.Params;
@@ -34,31 +31,26 @@ public class BitgetMarketDataService extends BitgetMarketDataServiceRaw
     super(exchange);
   }
 
-  @Override
-  public Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
+  public List<Currency> getCurrencies() throws IOException {
     try {
       return getBitgetCoinDtoList(null).stream()
           .map(BitgetCoinDto::getCurrency)
           .distinct()
-          .collect(
-              Collectors.toMap(
-                  currency -> currency, currency -> CurrencyMetaData.builder().build()));
+          .collect(Collectors.toList());
     } catch (BitgetException e) {
       throw BitgetErrorAdapter.adapt(e);
     }
   }
 
-  @Override
-  public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
+  public List<Instrument> getInstruments() throws IOException {
     try {
       List<BitgetSymbolDto> metadata = getBitgetSymbolDtos(null);
 
       return metadata.stream()
           .filter(details -> details.getStatus() == Status.ONLINE)
+          .map(BitgetSymbolDto::getCurrencyPair)
           .distinct()
-          .collect(
-              Collectors.toMap(
-                  BitgetSymbolDto::getCurrencyPair, (BitgetAdapters::toInstrumentMetaData)));
+          .collect(Collectors.toList());
     } catch (BitgetException e) {
       throw BitgetErrorAdapter.adapt(e);
     }

--- a/xchange-bitget/src/test/java/org/knowm/xchange/bitget/service/BitgetMarketDataServiceIntegration.java
+++ b/xchange-bitget/src/test/java/org/knowm/xchange/bitget/service/BitgetMarketDataServiceIntegration.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchange.bitget.BitgetIntegrationTestParent;
 import org.knowm.xchange.currency.Currency;
@@ -13,8 +12,6 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
-import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.exceptions.InstrumentNotValidException;
 import org.knowm.xchange.instrument.Instrument;
 
@@ -34,20 +31,20 @@ class BitgetMarketDataServiceIntegration extends BitgetIntegrationTestParent {
 
   @Test
   void valid_currencies() throws IOException {
-    Map<Currency, CurrencyMetaData> currencies =
+    List<Currency> currencies =
         ((BitgetMarketDataService) exchange.getMarketDataService()).getCurrencies();
 
     assertThat(currencies).isNotEmpty();
-    assertThat(currencies.keySet().stream().distinct().count()).isEqualTo(currencies.size());
+    assertThat(currencies.stream().distinct().count()).isEqualTo(currencies.size());
   }
 
   @Test
   void valid_instruments() throws IOException {
-    Map<Instrument, InstrumentMetaData> instruments =
+    List<Instrument> instruments =
         ((BitgetMarketDataService) exchange.getMarketDataService()).getInstruments();
 
     assertThat(instruments).isNotEmpty();
-    assertThat(instruments.keySet().stream().distinct().count()).isEqualTo(instruments.size());
+    assertThat(instruments.stream().distinct().count()).isEqualTo(instruments.size());
   }
 
   @Test

--- a/xchange-bybit/src/main/java/org/knowm/xchange/bybit/BybitExchange.java
+++ b/xchange-bybit/src/main/java/org/knowm/xchange/bybit/BybitExchange.java
@@ -48,8 +48,8 @@ public class BybitExchange extends BaseExchange {
     // initialize currency pairs & currencies
     exchangeMetaData =
         new ExchangeMetaData(
-            marketDataService.getInstruments(),
-            marketDataService.getCurrencies(),
+            ((BybitMarketDataService) marketDataService).getInstruments(),
+            ((BybitMarketDataService) marketDataService).getCurrencies(),
             null,
             null,
             true);

--- a/xchange-bybit/src/main/java/org/knowm/xchange/bybit/service/BybitMarketDataService.java
+++ b/xchange-bybit/src/main/java/org/knowm/xchange/bybit/service/BybitMarketDataService.java
@@ -71,7 +71,6 @@ public class BybitMarketDataService extends BybitMarketDataServiceRaw implements
     return getTicker((Instrument) currencyPair, args);
   }
 
-  @Override
   public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
     Map<Instrument, InstrumentMetaData> instrumentsMap = new HashMap<>();
 
@@ -99,7 +98,6 @@ public class BybitMarketDataService extends BybitMarketDataServiceRaw implements
     return instrumentsMap;
   }
 
-  @Override
   public Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
     return new HashMap<>(
         BybitAdapters.adaptBybitCurrencies(

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/CoinbaseProExchange.java
@@ -121,8 +121,8 @@ public class CoinbaseProExchange extends BaseExchange {
   public void remoteInit() throws IOException {
     exchangeMetaData =
         new ExchangeMetaData(
-            marketDataService.getInstruments(),
-            marketDataService.getCurrencies(),
+            ((CoinbaseProMarketDataService) marketDataService).getInstruments(),
+            ((CoinbaseProMarketDataService) marketDataService).getCurrencies(),
             exchangeMetaData == null ? null : exchangeMetaData.getPublicRateLimits(),
             exchangeMetaData == null ? null : exchangeMetaData.getPrivateRateLimits(),
             true);

--- a/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProMarketDataService.java
+++ b/xchange-coinbasepro/src/main/java/org/knowm/xchange/coinbasepro/service/CoinbaseProMarketDataService.java
@@ -133,12 +133,10 @@ public class CoinbaseProMarketDataService extends CoinbaseProMarketDataServiceRa
     throw new IllegalArgumentException("Invalid arguments passed to getTrades");
   }
 
-  @Override
   public Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
     return CoinbaseProAdapters.adaptCoinbaseProCurrencies(getCoinbaseProCurrencies());
   }
 
-  @Override
   public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
     return CoinbaseProAdapters.adaptCoinbaseProCurrencyPairs(getCoinbaseProProducts());
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/marketdata/MarketDataService.java
@@ -2,14 +2,15 @@ package org.knowm.xchange.service.marketdata;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.marketdata.*;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
+import org.knowm.xchange.dto.marketdata.CandleStickData;
+import org.knowm.xchange.dto.marketdata.FundingRate;
+import org.knowm.xchange.dto.marketdata.FundingRates;
+import org.knowm.xchange.dto.marketdata.OrderBook;
+import org.knowm.xchange.dto.marketdata.Ticker;
+import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
-import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
@@ -245,39 +246,5 @@ public interface MarketDataService extends BaseService {
    */
   default FundingRate getFundingRate(Instrument instrument) throws IOException {
     throw new NotYetImplementedForExchangeException("getFundingRate");
-  }
-
-  /**
-   * Get currencies currently provided by the exchange
-   *
-   * @return The list of currencies, null if some sort of error occurred. Implementers should log
-   *     the error.
-   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
-   *     request or response
-   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
-   *     requested function or data
-   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
-   *     requested function or data, but it has not yet been implemented
-   * @throws IOException - Indication that a networking error occurred while fetching JSON data
-   */
-  default Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
-    throw new NotYetImplementedForExchangeException("getCurrencies");
-  }
-
-  /**
-   * Get instruments/currency pairs currently provided by the exchange
-   *
-   * @return The list of instruments/currency pairs, null if some sort of error occurred.
-   *     Implementers should log the error.
-   * @throws ExchangeException - Indication that the exchange reported some kind of error with the
-   *     request or response
-   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the
-   *     requested function or data
-   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the
-   *     requested function or data, but it has not yet been implemented
-   * @throws IOException - Indication that a networking error occurred while fetching JSON data
-   */
-  default Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
-    throw new NotYetImplementedForExchangeException("getInstruments");
   }
 }

--- a/xchange-finery-markets/src/main/java/org/knowm/xchange/finerymarkets/FineryMarketsExchange.java
+++ b/xchange-finery-markets/src/main/java/org/knowm/xchange/finerymarkets/FineryMarketsExchange.java
@@ -48,8 +48,8 @@ public class FineryMarketsExchange extends BaseExchange {
     // initialize currency pairs & currencies
     exchangeMetaData =
         new ExchangeMetaData(
-            marketDataService.getInstruments(),
-            marketDataService.getCurrencies(),
+            ((FineryMarketsMarketDataService) marketDataService).getInstruments(),
+            ((FineryMarketsMarketDataService) marketDataService).getCurrencies(),
             null,
             null,
             true);

--- a/xchange-finery-markets/src/main/java/org/knowm/xchange/finerymarkets/service/FineryMarketsMarketDataService.java
+++ b/xchange-finery-markets/src/main/java/org/knowm/xchange/finerymarkets/service/FineryMarketsMarketDataService.java
@@ -17,12 +17,10 @@ public class FineryMarketsMarketDataService extends FineryMarketsMarketDataServi
     super(exchange);
   }
 
-  @Override
   public Map<Currency, CurrencyMetaData> getCurrencies() {
     return adaptCurrencies(getFineryMarketsInstruments());
   }
 
-  @Override
   public Map<Instrument, InstrumentMetaData> getInstruments() {
     return adaptInstruments(getFineryMarketsInstruments());
   }

--- a/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
+++ b/xchange-gateio-v4/src/main/java/org/knowm/xchange/gateio/service/GateioMarketDataService.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.Validate;
 import org.knowm.xchange.currency.Currency;
@@ -14,7 +13,6 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.meta.ExchangeHealth;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
 import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.gateio.GateioAdapters;
 import org.knowm.xchange.gateio.GateioErrorAdapter;
@@ -97,25 +95,26 @@ public class GateioMarketDataService extends GateioMarketDataServiceRaw
     }
   }
 
-  @Override
-  public Map<Currency, CurrencyMetaData> getCurrencies() throws IOException {
+  public List<Currency> getCurrencies() throws IOException {
     try {
       List<GateioCurrencyInfo> currencyInfos = getGateioCurrencyInfos();
       return currencyInfos.stream()
           .filter(gateioCurrencyInfo -> !gateioCurrencyInfo.getDelisted())
           .map(GateioCurrencyInfo::getCurrency)
-          .distinct()
-          .collect(
-              Collectors.toMap(Function.identity(), currency -> new CurrencyMetaData(0, null)));
+          .collect(Collectors.toList());
     } catch (GateioException e) {
       throw GateioErrorAdapter.adapt(e);
     }
   }
 
-  @Override
-  public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
+  public List<CurrencyPair> getCurrencyPairs() throws IOException {
     try {
-      return GateioAdapters.toInstruments(getCurrencyPairDetails());
+      List<GateioCurrencyPairDetails> metadata = getCurrencyPairDetails();
+
+      return metadata.stream()
+          .filter(details -> "tradable".equals(details.getTradeStatus()))
+          .map(details -> new CurrencyPair(details.getAsset(), details.getQuote()))
+          .collect(Collectors.toList());
     } catch (GateioException e) {
       throw GateioErrorAdapter.adapt(e);
     }

--- a/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceTest.java
+++ b/xchange-gateio-v4/src/test/java/org/knowm/xchange/gateio/service/GateioMarketDataServiceTest.java
@@ -8,18 +8,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
-import org.knowm.xchange.dto.meta.CurrencyMetaData;
-import org.knowm.xchange.dto.meta.InstrumentMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.gateio.GateioExchangeWiremock;
-import org.knowm.xchange.instrument.Instrument;
 
 public class GateioMarketDataServiceTest extends GateioExchangeWiremock {
 
@@ -94,17 +90,16 @@ public class GateioMarketDataServiceTest extends GateioExchangeWiremock {
 
   @Test
   void getCurrencies_valid() throws IOException {
-    Map<Currency, CurrencyMetaData> actual = gateioMarketDataService.getCurrencies();
+    List<Currency> actual = gateioMarketDataService.getCurrencies();
 
-    assertThat(actual.keySet()).containsOnly(Currency.BTC, Currency.ETH);
+    assertThat(actual).containsOnly(Currency.BTC, Currency.ETH);
   }
 
   @Test
   void getCurrencyPairs_valid() throws IOException {
-    Map<Instrument, InstrumentMetaData> actual = gateioMarketDataService.getInstruments();
+    List<CurrencyPair> actual = gateioMarketDataService.getCurrencyPairs();
 
     assertThat(actual)
-        .containsOnlyKeys(
-            CurrencyPair.BTC_USDT, CurrencyPair.ETH_USDT, new CurrencyPair("CHZ/USDT"));
+        .containsOnly(CurrencyPair.BTC_USDT, CurrencyPair.ETH_USDT, new CurrencyPair("CHZ/USDT"));
   }
 }

--- a/xchange-thalex/src/main/java/org/knowm/xchange/thalex/services/ThalexMarketDataService.java
+++ b/xchange-thalex/src/main/java/org/knowm/xchange/thalex/services/ThalexMarketDataService.java
@@ -17,7 +17,6 @@ public class ThalexMarketDataService extends ThalexMarketDataServiceRaw
     super(exchange);
   }
 
-  @Override
   public Map<Instrument, InstrumentMetaData> getInstruments() throws IOException {
     List<ThalexInstrumentDto> thalexInstruments = getThalexInstrument();
     return ThalexAdapters.toInstrumentsMap(thalexInstruments);


### PR DESCRIPTION
- Removed methods from interface (`MarketDataService#getCurrencies`, `MarketDataService#getInstruments`)
- Replaced implementation with the one in main repo (if exists):
  - bitfinex
  - bitget
  - gateio-v4
- Left existing ones untouched because they're used in remoteInit(). Has to be checked further:
  - bybit
  - coinbasepro
  - finery-markets
  - thalex
