### PR TITLE
deribit: private-socket-only lifecycle + venue application heartbeat

### DIFF
--- a/xchange-stream-deribit/src/main/java/info/bitrich/xchangestream/deribit/DeribitStreamingExchange.java
+++ b/xchange-stream-deribit/src/main/java/info/bitrich/xchangestream/deribit/DeribitStreamingExchange.java
@@ -2,7 +2,6 @@ package info.bitrich.xchangestream.deribit;
 
 import info.bitrich.xchangestream.core.ProductSubscription;
 import info.bitrich.xchangestream.core.StreamingExchange;
-import info.bitrich.xchangestream.core.StreamingMarketDataService;
 import info.bitrich.xchangestream.core.StreamingTradeService;
 import info.bitrich.xchangestream.deribit.config.Config;
 import io.reactivex.rxjava3.core.Completable;
@@ -12,27 +11,25 @@ import org.knowm.xchange.deribit.v2.DeribitExchange;
 @Getter
 public class DeribitStreamingExchange extends DeribitExchange implements StreamingExchange {
 
-  private DeribitStreamingService publicStreamingService;
   private DeribitPrivateStreamingService privateStreamingService;
-
-  private StreamingMarketDataService streamingMarketDataService;
   private StreamingTradeService streamingTradeService;
 
+  /**
+   * Opens the private (execution-report) socket only. Deribit market data is deliberately not
+   * served by this connector — the rate distributor owns its own market-data websocket — so no
+   * public socket is opened here, and {@link #disconnect()} closes exactly what was opened.
+   */
   @Override
   public Completable connect(ProductSubscription... args) {
-    String wsUrl = getWsUrl();
-
-    publicStreamingService = new DeribitStreamingService(wsUrl);
-
-    privateStreamingService = new DeribitPrivateStreamingService(wsUrl, exchangeSpecification.getApiKey(), exchangeSpecification.getSecretKey());
-    privateStreamingService.connect().blockingAwait();
-
-    applyStreamingSpecification(exchangeSpecification, publicStreamingService);
-
-    streamingMarketDataService = new DeribitStreamingMarketDataService(publicStreamingService);
+    privateStreamingService = createPrivateStreamingService(getWsUrl());
+    applyStreamingSpecification(exchangeSpecification, privateStreamingService);
     streamingTradeService = new DeribitStreamingTradeService(privateStreamingService);
+    return privateStreamingService.connect();
+  }
 
-    return publicStreamingService.connect();
+  /** Test seam: lets a test substitute a recording private service. */
+  DeribitPrivateStreamingService createPrivateStreamingService(String wsUrl) {
+    return new DeribitPrivateStreamingService(wsUrl, exchangeSpecification.getApiKey(), exchangeSpecification.getSecretKey());
   }
 
   /**
@@ -53,20 +50,19 @@ public class DeribitStreamingExchange extends DeribitExchange implements Streami
 
   @Override
   public Completable disconnect() {
-    DeribitStreamingService service = publicStreamingService;
-    publicStreamingService = null;
-    streamingMarketDataService = null;
+    DeribitPrivateStreamingService service = privateStreamingService;
+    privateStreamingService = null;
     streamingTradeService = null;
-    return service.disconnect();
+    return service == null ? Completable.complete() : service.disconnect();
   }
 
   @Override
   public boolean isAlive() {
-    return publicStreamingService != null && publicStreamingService.isSocketOpen();
+    return privateStreamingService != null && privateStreamingService.isSocketOpen();
   }
 
   @Override
   public void useCompressedMessages(boolean compressedMessages) {
-    publicStreamingService.useCompressedMessages(compressedMessages);
+    privateStreamingService.useCompressedMessages(compressedMessages);
   }
 }

--- a/xchange-stream-deribit/src/main/java/info/bitrich/xchangestream/deribit/DeribitStreamingService.java
+++ b/xchange-stream-deribit/src/main/java/info/bitrich/xchangestream/deribit/DeribitStreamingService.java
@@ -10,6 +10,7 @@ import info.bitrich.xchangestream.deribit.dto.request.DeribitWsRequest.Params;
 import info.bitrich.xchangestream.deribit.dto.response.DeribitEventNotification;
 import info.bitrich.xchangestream.deribit.dto.response.DeribitWsNotification;
 import info.bitrich.xchangestream.service.netty.NettyStreamingService;
+import io.reactivex.rxjava3.core.Completable;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +18,31 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DeribitStreamingService extends NettyStreamingService<DeribitWsNotification> {
 
+  /** Deribit accepts 10-300s; 30s matches the rate distributor's proven setting. */
+  static final int HEARTBEAT_INTERVAL_SECONDS = 30;
+
   protected final ObjectMapper objectMapper = Config.getInstance().getObjectMapper();
 
   public DeribitStreamingService(String apiUri) {
     super(apiUri, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Arms Deribit's application heartbeat after every completed open (first connect and every
+   * auto-reconnect). Protocol-level ping frames do not count as activity for Deribit's heartbeat
+   * mechanism, so without this the server drops the connection after the heartbeat timeout.
+   */
+  @Override
+  protected Completable openConnection() {
+    return super.openConnection().doOnComplete(this::enableHeartbeat);
+  }
+
+  void enableHeartbeat() {
+    ObjectNode request = objectMapper.createObjectNode();
+    request.put("jsonrpc", "2.0");
+    request.put("method", "public/set_heartbeat");
+    request.putObject("params").put("interval", HEARTBEAT_INTERVAL_SECONDS);
+    sendMessage(request.toString());
   }
 
   @Override
@@ -64,6 +86,19 @@ public class DeribitStreamingService extends NettyStreamingService<DeribitWsNoti
     // Parse incoming message to JSON
     try {
       JsonNode jsonNode = objectMapper.readTree(message);
+
+      // Heartbeats are answered here at the raw layer and never reach a channel: the server
+      // only keeps the connection when a test_request is answered with a public/test.
+      if ("heartbeat".equals(jsonNode.path("method").asText())) {
+        if ("test_request".equals(jsonNode.path("params").path("type").asText())) {
+          ObjectNode reply = objectMapper.createObjectNode();
+          reply.put("jsonrpc", "2.0");
+          reply.put("method", "public/test");
+          reply.putObject("params");
+          sendMessage(reply.toString());
+        }
+        return;
+      }
 
       // try to parse event
       if (jsonNode.has("result")) {

--- a/xchange-stream-deribit/src/test/java/info/bitrich/xchangestream/deribit/DeribitStreamingExchangeTest.java
+++ b/xchange-stream-deribit/src/test/java/info/bitrich/xchangestream/deribit/DeribitStreamingExchangeTest.java
@@ -1,10 +1,17 @@
 package info.bitrich.xchangestream.deribit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import info.bitrich.xchangestream.deribit.config.Config;
+import io.reactivex.rxjava3.core.Completable;
 import org.junit.jupiter.api.Test;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.junit.jupiter.api.BeforeEach;
 
 class DeribitStreamingExchangeTest {
@@ -49,5 +56,68 @@ class DeribitStreamingExchangeTest {
     exchange.applySpecification(specification);
 
     assertEquals("ws://127.0.0.1:9100/override", exchange.getWsUrl());
+  }
+
+  /** Records lifecycle calls instead of opening a real socket. */
+  private static class RecordingPrivateService extends DeribitPrivateStreamingService {
+    boolean connected;
+    boolean disconnected;
+
+    RecordingPrivateService() {
+      super("ws://127.0.0.1:9100/test", "key", "secret");
+    }
+
+    @Override
+    public Completable connect() {
+      return Completable.fromAction(() -> connected = true);
+    }
+
+    @Override
+    public Completable disconnect() {
+      return Completable.fromAction(() -> disconnected = true);
+    }
+  }
+
+  private DeribitStreamingExchange exchangeWith(RecordingPrivateService fake) {
+    DeribitStreamingExchange fakeBacked = new DeribitStreamingExchange() {
+      @Override
+      DeribitPrivateStreamingService createPrivateStreamingService(String wsUrl) {
+        return fake;
+      }
+    };
+    ExchangeSpecification spec = fakeBacked.getDefaultExchangeSpecification();
+    spec.setShouldLoadRemoteMetaData(false);
+    fakeBacked.applySpecification(spec);
+    return fakeBacked;
+  }
+
+  @Test
+  void connectOpensOnlyThePrivateSocket() {
+    RecordingPrivateService fake = new RecordingPrivateService();
+    DeribitStreamingExchange fakeBacked = exchangeWith(fake);
+
+    fakeBacked.connect().blockingAwait();
+
+    assertTrue(fake.connected);
+    assertSame(fake, fakeBacked.getPrivateStreamingService());
+    assertNotNull(fakeBacked.getStreamingTradeService());
+  }
+
+  @Test
+  void disconnectClosesThePrivateSocket() {
+    RecordingPrivateService fake = new RecordingPrivateService();
+    DeribitStreamingExchange fakeBacked = exchangeWith(fake);
+    fakeBacked.connect().blockingAwait();
+
+    fakeBacked.disconnect().blockingAwait();
+
+    assertTrue(fake.disconnected);
+    assertNull(fakeBacked.getPrivateStreamingService());
+    assertNull(fakeBacked.getStreamingTradeService());
+  }
+
+  @Test
+  void marketDataIsNotServedByThisConnector() {
+    assertThrows(NotYetImplementedForExchangeException.class, exchange::getStreamingMarketDataService);
   }
 }

--- a/xchange-stream-deribit/src/test/java/info/bitrich/xchangestream/deribit/DeribitStreamingServiceHeartbeatTest.java
+++ b/xchange-stream-deribit/src/test/java/info/bitrich/xchangestream/deribit/DeribitStreamingServiceHeartbeatTest.java
@@ -1,0 +1,79 @@
+package info.bitrich.xchangestream.deribit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import info.bitrich.xchangestream.deribit.dto.response.DeribitWsNotification;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deribit's server keeps a connection only when its heartbeat test_request is answered with a
+ * public/test JSON message — protocol-level ping frames do not count (venue guidance, 2026-08-20
+ * traffic complaint). These tests pin the raw-layer heartbeat handling.
+ */
+class DeribitStreamingServiceHeartbeatTest {
+
+  /** Captures outgoing messages and parsed notifications instead of using a socket. */
+  private static class RecordingService extends DeribitStreamingService {
+    final List<String> sent = new ArrayList<>();
+    final List<DeribitWsNotification> handled = new ArrayList<>();
+
+    RecordingService() {
+      super("ws://127.0.0.1:9100/test");
+    }
+
+    @Override
+    public void sendMessage(String message) {
+      sent.add(message);
+    }
+
+    @Override
+    protected void handleMessage(DeribitWsNotification message) {
+      handled.add(message);
+    }
+  }
+
+  @Test
+  void answersATestRequestWithPublicTest() {
+    RecordingService service = new RecordingService();
+
+    service.messageHandler("{\"jsonrpc\":\"2.0\",\"method\":\"heartbeat\",\"params\":{\"type\":\"test_request\"}}");
+
+    assertEquals(1, service.sent.size());
+    assertTrue(service.sent.get(0).contains("\"method\":\"public/test\""));
+    assertTrue(service.handled.isEmpty());
+  }
+
+  @Test
+  void swallowsAnOrdinaryHeartbeatWithoutReplying() {
+    RecordingService service = new RecordingService();
+
+    service.messageHandler("{\"jsonrpc\":\"2.0\",\"method\":\"heartbeat\",\"params\":{\"type\":\"heartbeat\"}}");
+
+    assertTrue(service.sent.isEmpty());
+    assertTrue(service.handled.isEmpty());
+  }
+
+  @Test
+  void armsTheHeartbeatWithTheAgreedInterval() {
+    RecordingService service = new RecordingService();
+
+    service.enableHeartbeat();
+
+    assertEquals(1, service.sent.size());
+    assertTrue(service.sent.get(0).contains("\"method\":\"public/set_heartbeat\""));
+    assertTrue(service.sent.get(0).contains("\"interval\":" + DeribitStreamingService.HEARTBEAT_INTERVAL_SECONDS));
+  }
+
+  @Test
+  void ordinaryMessagesStillReachTheChannelHandler() {
+    RecordingService service = new RecordingService();
+
+    service.messageHandler("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}");
+
+    assertTrue(service.sent.isEmpty());
+    assertEquals(1, service.handled.size());
+  }
+}


### PR DESCRIPTION
## Incident
Demo2 accumulated ~528 concurrent Deribit websocket clients in reconnect loops (>=5000 handshakes/10min); Deribit rate-limited the subaccount (429) and complained about the traffic (2026-08-20). Leak rate: +1 client per 15-minute account rebuild, for ~6 days.

## Root causes (in this connector)
1. **Lifecycle asymmetry.** `connect()` opened TWO sockets (public + private) but `disconnect()` closed only the public one. ABOS consumes only the private (execution-report/fills) socket; Deribit market data is served by the rate distributor's own websocket. So every rebuild abandoned the one socket that matters, alive, with its auto-reconnect armed — an immortal zombie per cycle.
2. **No application heartbeat.** The connector never sent `public/set_heartbeat` and never answered `test_request` with `public/test`; it only sent protocol-level ping frames, which Deribit ignores. Every connection was dropped at the heartbeat timeout, feeding the reconnect churn.

## Fixes (two commits, each independently witnessable)
- **Private socket only:** `connect()` opens the private service only (and now applies the streaming specification to it — previously it was applied only to the discarded public service); `disconnect()` closes exactly what was opened and tolerates a double call. Market data deliberately reverts to the `StreamingExchange` default (not served here).
- **Venue heartbeat:** `public/set_heartbeat` (30s, mirroring the rate distributor's proven setting) is armed after every completed open, including every auto-reconnect; `test_request` is answered with `public/test` at the raw-message layer so heartbeats never reach subscription channels.

## Deliberately NOT in this PR
`NettyStreamingService` reconnect hardening (cancellable reconnect task, terminal lifecycle state, no event-loop-group resurrection) — follow-up unit, needs regression coverage for KuCoin/Thalex same-instance reconnect semantics first.

## Tests
- `DeribitStreamingExchangeTest`: connect opens only the private socket; disconnect closes it; market data not served (7 tests total).
- `DeribitStreamingServiceHeartbeatTest`: test_request answered with public/test; ordinary heartbeat swallowed; set_heartbeat armed with 30s; ordinary messages still reach the channel handler (4 tests).

## Witness plan (demo2, after deploy)
Exactly one Deribit socket per configured account, flat across two 15-min cycles; `set_heartbeat` on every connect; every `test_request` answered; no 429s; no "Reopening Websocket Client" during healthy operation; fills confirmed by a small live trade + gapfill clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)