### PR TITLE
[kucoin] Balances from the private websocket, and the futures wallet over REST

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinAccountServiceRaw.java
@@ -12,6 +12,7 @@ import org.knowm.xchange.kucoin.dto.request.CreateDepositAddressApiRequest;
 import org.knowm.xchange.kucoin.dto.request.InnerTransferRequest;
 import org.knowm.xchange.kucoin.dto.response.AccountBalancesResponse;
 import org.knowm.xchange.kucoin.dto.response.AccountLedgersResponse;
+import org.knowm.xchange.kucoin.dto.response.FuturesAccountOverviewResponse;
 import org.knowm.xchange.kucoin.dto.response.ApplyWithdrawResponse;
 import org.knowm.xchange.kucoin.dto.response.DepositAddressResponse;
 import org.knowm.xchange.kucoin.dto.response.DepositResponse;
@@ -41,6 +42,26 @@ public class KucoinAccountServiceRaw extends KucoinBaseService {
         .call()
         .getData();
   }
+  /**
+   * The futures wallet for a single currency.
+   *
+   * <p>The {@code /contractAccount/wallet} websocket channel only emits on change,
+   * so a caller needs this to establish a starting balance and to re-synchronise
+   * after a reconnection. Requires an exchange whose base URI points at the futures
+   * host — see {@link AccountAPI#getFuturesAccountOverview}.
+   */
+  public FuturesAccountOverviewResponse getKucoinFuturesAccountOverview(String currency)
+      throws IOException {
+    return decorateApiCall(
+            () ->
+                accountApi.getFuturesAccountOverview(
+                    apiKey, digest, nonceFactory, passphrase, "2", currency))
+        .withRetry(retry("futuresAccountOverview"))
+        .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+        .call()
+        .getData();
+  }
+
   public Pagination<SubAccountsResponse> getKucoinSubAccounts(Integer pageSize, Integer currentPage)
       throws IOException {
     checkAuthenticated();

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/FuturesAccountOverviewResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/FuturesAccountOverviewResponse.java
@@ -1,0 +1,67 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+import lombok.Data;
+
+/**
+ * The futures wallet for a single currency — {@code GET /api/v1/account-overview}.
+ *
+ * <p>This endpoint exists only on the futures host. The spot account endpoint
+ * ({@code /api/v1/accounts}) returns 404 there, and this one returns 404 on the
+ * spot host, so an exchange must have its base URI pointed at the futures host
+ * before this can be called.
+ *
+ * <p>Note that this response and the {@code /contractAccount/wallet} websocket
+ * channel name the same quantities differently: {@code marginBalance} /
+ * {@code frozenFunds} / {@code accountEquity} here against {@code walletBalance} /
+ * {@code holdBalance} / {@code equity} on the channel. Anything consuming both
+ * needs to map them separately.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FuturesAccountOverviewResponse {
+
+  /** Currency of this wallet, e.g. USDT. */
+  private String currency;
+
+  /** Margin balance plus unrealised profit and loss. */
+  private BigDecimal accountEquity;
+
+  /**
+   * Margin balance.
+   *
+   * <p>Believed to be the equivalent of the websocket channel's
+   * {@code walletBalance}, but not confirmed: on an account with no open position
+   * this field, {@code accountEquity}, {@code availableBalance},
+   * {@code availableMargin} and {@code maxWithdrawAmount} all carry the same value,
+   * so such a reading cannot distinguish them. Confirming the correspondence needs
+   * an account with an open position, where unrealised profit and committed margin
+   * are non-zero.
+   */
+  private BigDecimal marginBalance;
+
+  /** Balance available to use. Named identically on the websocket channel. */
+  private BigDecimal availableBalance;
+
+  /** Margin available to use. */
+  private BigDecimal availableMargin;
+
+  /** Funds on hold. The websocket channel names this {@code holdBalance}. */
+  private BigDecimal frozenFunds;
+
+  /** Maximum amount currently withdrawable. */
+  private BigDecimal maxWithdrawAmount;
+
+  /** Margin committed to open orders. */
+  private BigDecimal orderMargin;
+
+  /** Margin committed to open positions. */
+  private BigDecimal positionMargin;
+
+  /** Unrealised profit and loss on open positions. */
+  private BigDecimal unrealisedPNL;
+
+  /** Risk ratio. */
+  private BigDecimal riskRatio;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/AccountAPI.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.kucoin.dto.request.InnerTransferRequest;
 import org.knowm.xchange.kucoin.dto.response.AccountBalancesResponse;
 import org.knowm.xchange.kucoin.dto.response.AccountLedgersResponse;
 import org.knowm.xchange.kucoin.dto.response.AccountResponse;
+import org.knowm.xchange.kucoin.dto.response.FuturesAccountOverviewResponse;
 import org.knowm.xchange.kucoin.dto.response.InternalTransferResponse;
 import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
@@ -51,6 +52,29 @@ public interface AccountAPI {
       @HeaderParam(APIConstants.API_HEADER_KEY_VERSION) String apiKeyVersion,
       @QueryParam("currency") String currency,
       @QueryParam("type") String type)
+      throws IOException, KucoinException;
+
+  /**
+   * Get the futures wallet for a single currency.
+   *
+   * <p>Futures host only: this endpoint returns 404 on the spot host, as
+   * {@code /api/v1/accounts} does on the futures host. The exchange's base URI must
+   * point at the futures host before calling this.
+   *
+   * @param currency The code of the currency, e.g. USDT.
+   * @return The futures wallet.
+   * @throws IOException on socket errors.
+   * @throws KucoinApiException when errors are returned from the exchange.
+   */
+  @GET
+  @Path("v1/account-overview")
+  KucoinResponse<FuturesAccountOverviewResponse> getFuturesAccountOverview(
+      @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
+      @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,
+      @HeaderParam(APIConstants.API_HEADER_TIMESTAMP) SynchronizedValueFactory<Long> nonce,
+      @HeaderParam(APIConstants.API_HEADER_PASSPHRASE) String apiPassphrase,
+      @HeaderParam(APIConstants.API_HEADER_KEY_VERSION) String apiKeyVersion,
+      @QueryParam("currency") String currency)
       throws IOException, KucoinException;
 
   @POST

--- a/xchange-stream-kucoin/pom.xml
+++ b/xchange-stream-kucoin/pom.xml
@@ -33,5 +33,12 @@
             <version>${project.parent.version}</version>
         </dependency>
 
+        <!-- This module's first tests. assertj comes from the parent's shared set. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingAccountService.java
+++ b/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingAccountService.java
@@ -8,6 +8,8 @@ import info.bitrich.xchangestream.kucoin.dto.account.KucoinWsSpotBalanceEvent;
 import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
 import io.reactivex.rxjava3.core.Observable;
 import lombok.RequiredArgsConstructor;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.OpenPosition;
 import org.knowm.xchange.instrument.Instrument;
@@ -42,6 +44,68 @@ public class KucoinStreamingAccountService implements StreamingAccountService {
         .subscribeChannel("/contract/position:" + symbol)
         .filter(jsonNode -> SUBJECT_POSITION_SETTLEMENT.equals(jsonNode.path("subject").asText(null)))
         .map(node -> mapper.convertValue(node, KucoinWsPositionsEvent.class));
+  }
+
+  /**
+   * Spot balances for the logged-in user.
+   *
+   * <p>Distinct from {@link #getSpotLedgerChanges}, which adapts the same channel to
+   * a {@link FundingRecord} for funding-history callers and so reports the change
+   * rather than the resulting balance. This reports the total, available and held
+   * amounts as they stand after each change.
+   *
+   * <p>Filtered to {@code currency} when one is given, all currencies when null. The
+   * exchange emits one frame per currency and account rather than a full snapshot,
+   * so a caller should apply each frame to the currency it names and must not treat
+   * one as a complete picture.
+   */
+  @Override
+  public Observable<Balance> getBalanceChanges(Currency currency, Object... args) {
+    return getRawSpotBalanceChanges()
+        .map(event -> KucoinStreamingAdapters.adaptBalance(event.getData()))
+        .filter(balance -> currency == null || currency.equals(balance.getCurrency()));
+  }
+
+  /**
+   * Futures wallet balances for the logged-in user, with the wallet balance as the
+   * total.
+   *
+   * <p>Requires an exchange whose base URI points at the futures host, since the
+   * channel is served only there.
+   */
+  public Observable<Balance> getFuturesBalanceChanges(Currency currency) {
+    return getRawFuturesWalletChanges()
+        .map(event -> KucoinStreamingAdapters.adaptBalance(event.getData()))
+        .filter(balance -> currency == null || currency.equals(balance.getCurrency()));
+  }
+
+  /**
+   * Raw spot balance frames.
+   *
+   * <p>For callers needing what {@link Balance} cannot carry — chiefly
+   * {@code relationEvent}, which identifies the account the change occurred in
+   * (main, trade, margin, isolated). The channel covers every account type of the
+   * logged-in user, and one currency exists in several of them at once, so a frame
+   * stripped of that field cannot be attributed to an account.
+   */
+  public Observable<KucoinWsSpotBalanceEvent> getRawSpotBalanceChanges() {
+    return service.subscribeChannel("/account/balance")
+        .filter(jsonNode -> SUBJECT_SPOT_BALANCE.equals(jsonNode.path("subject").asText(null)))
+        .map(jsonNode -> mapper.convertValue(jsonNode, KucoinWsSpotBalanceEvent.class));
+  }
+
+  /**
+   * Raw futures wallet frames.
+   *
+   * <p>For callers needing what {@link Balance} cannot carry — the cross and
+   * isolated margin breakdown, unrealised profit and loss, and {@code version},
+   * which the exchange increments on every change and is therefore the only way to
+   * detect a frame that never arrived. The spot channel carries no equivalent.
+   */
+  public Observable<KucoinWsFuturesBalanceEvent> getRawFuturesWalletChanges() {
+    return service.subscribeChannel("/contractAccount/wallet")
+        .filter(jsonNode -> SUBJECT_FUTURES_BALANCE.equals(jsonNode.path("subject").asText(null)))
+        .map(jsonNode -> mapper.convertValue(jsonNode, KucoinWsFuturesBalanceEvent.class));
   }
 
   @Override

--- a/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingAdapters.java
+++ b/xchange-stream-kucoin/src/main/java/info/bitrich/xchangestream/kucoin/KucoinStreamingAdapters.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.dto.account.FundingRecord.Status;
 import org.knowm.xchange.dto.account.FundingRecord.Type;
@@ -110,6 +111,62 @@ public class KucoinStreamingAdapters {
 
     throw new IllegalArgumentException(
         "Cannot determine base/quote for KuCoin futures symbol: " + symbol);
+  }
+
+  /**
+   * A spot balance frame to a {@link Balance}: the total, available and held amounts
+   * as they stand after the change.
+   *
+   * <p>Not the delta. {@code availableChange} states how much moved and is the right
+   * input for a {@link FundingRecord}; it is the wrong input for a balance.
+   *
+   * <p>A reported zero is preserved as zero rather than collapsed to null, so a
+   * caller can distinguish a drained account from an absent reading.
+   */
+  public static Balance adaptBalance(KucoinWsSpotBalanceData in) {
+    if (in == null) {
+      return null;
+    }
+
+    Balance.Builder builder =
+        Balance.builder()
+            .currency(in.getCurrency())
+            .total(in.getTotal())
+            .available(in.getAvailable())
+            .frozen(in.getHold());
+    if (in.getTime() != null) {
+      builder.timestamp(new Date(in.getTime()));
+    }
+    return builder.build();
+  }
+
+  /**
+   * A futures wallet frame to a {@link Balance}, taking the wallet balance as the
+   * total.
+   *
+   * <p>Not {@code equity}, which includes unrealised profit and loss on open
+   * positions and so varies with the market while no funds are transferred.
+   *
+   * <p>{@link Balance} has no room for the rest of the frame — the cross and
+   * isolated margin breakdown, the maximum withdrawable, and the {@code version}
+   * counter. Callers needing those should consume
+   * {@code KucoinStreamingAccountService#getRawFuturesWalletChanges} instead.
+   */
+  public static Balance adaptBalance(KucoinWsFuturesBalanceData in) {
+    if (in == null) {
+      return null;
+    }
+
+    Balance.Builder builder =
+        Balance.builder()
+            .currency(in.getCurrency())
+            .total(in.getWalletBalance())
+            .available(in.getAvailableBalance())
+            .frozen(in.getHoldBalance());
+    if (in.getTimestamp() != null) {
+      builder.timestamp(new Date(in.getTimestamp()));
+    }
+    return builder.build();
   }
 
   public static FundingRecord adaptFundingRecord(KucoinWsSpotBalanceData in) {

--- a/xchange-stream-kucoin/src/test/java/info/bitrich/xchangestream/kucoin/KucoinBalanceFrameTest.java
+++ b/xchange-stream-kucoin/src/test/java/info/bitrich/xchangestream/kucoin/KucoinBalanceFrameTest.java
@@ -1,0 +1,171 @@
+package info.bitrich.xchangestream.kucoin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import info.bitrich.xchangestream.kucoin.dto.account.KucoinWsFuturesBalanceData;
+import info.bitrich.xchangestream.kucoin.dto.account.KucoinWsFuturesBalanceEvent;
+import info.bitrich.xchangestream.kucoin.dto.account.KucoinWsSpotBalanceData;
+import info.bitrich.xchangestream.kucoin.dto.account.KucoinWsSpotBalanceEvent;
+import info.bitrich.xchangestream.kucoin.dto.enums.KucoinRelationEvent;
+import info.bitrich.xchangestream.service.netty.StreamingObjectMapperHelper;
+import java.io.IOException;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.Balance;
+
+/**
+ * Unmarshalling and adapter tests for the two private balance channels,
+ * {@code /account/balance} and {@code /contractAccount/wallet}.
+ *
+ * <p>The fixtures in {@code test/resources} are real exchange responses, captured
+ * by holding both authenticated sockets open while funds were moved between a spot
+ * account and its futures wallet. Only {@code walletBalance.change.with-open-position}
+ * is constructed, and only because the captured frame came from an account with no
+ * open position, where wallet balance and equity are necessarily equal and so cannot
+ * demonstrate which of the two an adapter reads.
+ */
+class KucoinBalanceFrameTest {
+
+  /**
+   * The mapper the streaming services use, rather than a fresh one: it is configured
+   * (unknown properties tolerated, unknown enum values defaulted, floating point read
+   * as exact decimals), and a test on differently configured mapper would exercise
+   * behaviour the production path never sees.
+   */
+  private final ObjectMapper mapper = StreamingObjectMapperHelper.getObjectMapper();
+
+  private <T> T read(String resource, Class<T> type) throws IOException {
+    return mapper.readValue(getClass().getClassLoader().getResourceAsStream(resource), type);
+  }
+
+  private KucoinWsSpotBalanceData spot(String resource) throws IOException {
+    return read(resource, KucoinWsSpotBalanceEvent.class).data;
+  }
+
+  private KucoinWsFuturesBalanceData futures(String resource) throws IOException {
+    return read(resource, KucoinWsFuturesBalanceEvent.class).data;
+  }
+
+  @Test
+  void unmarshalsSpotBalanceFrame() throws IOException {
+    KucoinWsSpotBalanceData data = spot("account.balance.json");
+
+    assertThat(data.getAccountId()).isEqualTo("180131510502404");
+    assertThat(data.getCurrency()).isEqualTo(Currency.USDT);
+    assertThat(data.getTotal()).isEqualByComparingTo("0");
+    assertThat(data.getAvailable()).isEqualByComparingTo("0");
+    assertThat(data.getHold()).isEqualByComparingTo("0");
+    assertThat(data.getAvailableChange()).isEqualByComparingTo("-50");
+    assertThat(data.getHoldChange()).isEqualByComparingTo("0");
+    assertThat(data.getRelationEventId()).isEqualTo("6a8ef86ba9b2d300073d5397");
+    assertThat(data.getTime()).isEqualTo(1787754603618L);
+  }
+
+  @Test
+  void unmarshalsAmountsSentAsStringsIntoExactDecimals() throws IOException {
+    // Every numeric value on this channel arrives as a JSON string, timestamps
+    // included. Reading them as doubles would lose precision on large balances.
+    KucoinWsSpotBalanceData data = spot("account.balance.json");
+
+    assertThat(data.getAvailableChange())
+        .isInstanceOf(BigDecimal.class)
+        .isEqualByComparingTo(new BigDecimal("-50"));
+  }
+
+  @Test
+  void unmarshalsRelationEventIdentifyingTheAccountThatMoved() throws IOException {
+    // The channel reports every account type of the logged-in user, so the subject
+    // alone does not say where the change happened. "trade.setted" is the trade
+    // account; the same currency exists concurrently in main, margin and isolated.
+    assertThat(spot("account.balance.json").getRelationEvent())
+        .isEqualTo(KucoinRelationEvent.TRADE_SETTED);
+  }
+
+  @Test
+  void adaptsSpotBalanceFrameToPostChangeBalance() throws IOException {
+    Balance balance = KucoinStreamingAdapters.adaptBalance(spot("account.balance.json"));
+
+    assertThat(balance.getCurrency()).isEqualTo(Currency.USDT);
+    // The state after the change, not the -50 delta that produced it.
+    assertThat(balance.getTotal()).isEqualByComparingTo("0");
+    assertThat(balance.getAvailable()).isEqualByComparingTo("0");
+    assertThat(balance.getFrozen()).isEqualByComparingTo("0");
+    assertThat(balance.getTimestamp()).isEqualTo(new java.util.Date(1787754603618L));
+  }
+
+  @Test
+  void adaptsAnEmptiedAccountToZeroRatherThanNull() throws IOException {
+    // The exchange reports "0" for a drained account. A null would be
+    // indistinguishable from an absent reading to a caller.
+    Balance balance = KucoinStreamingAdapters.adaptBalance(spot("account.balance.json"));
+
+    assertThat(balance.getTotal()).isNotNull().isEqualByComparingTo(BigDecimal.ZERO);
+  }
+
+  @Test
+  void adaptsSpotBalanceFrameWithoutTimestamp() throws IOException {
+    // An absent timestamp must cost the timestamp only. Constructing a Date from a
+    // null Long would fail the whole frame over one missing field.
+    Balance balance =
+        KucoinStreamingAdapters.adaptBalance(spot("account.balance.no-timestamp.json"));
+
+    assertThat(balance.getTotal()).isEqualByComparingTo("0");
+    assertThat(balance.getTimestamp()).isNull();
+  }
+
+  @Test
+  void unmarshalsFuturesWalletFrame() throws IOException {
+    KucoinWsFuturesBalanceData data = futures("walletBalance.change.json");
+
+    assertThat(data.getCurrency()).isEqualTo(Currency.USDT);
+    assertThat(data.getWalletBalance()).isEqualByComparingTo("50");
+    assertThat(data.getAvailableBalance()).isEqualByComparingTo("50");
+    assertThat(data.getHoldBalance()).isEqualByComparingTo("0");
+    assertThat(data.getEquity()).isEqualByComparingTo("50");
+    assertThat(data.getMaxWithdrawAmount()).isEqualByComparingTo("50");
+    assertThat(data.getTimestamp()).isEqualTo(1787754633355L);
+    // Incremented by the exchange on every change, so a caller can detect a frame
+    // it never received. The spot channel carries no equivalent.
+    assertThat(data.getVersion()).isEqualTo("18");
+  }
+
+  @Test
+  void unmarshalsFuturesWalletFrameIgnoringUndeclaredFields() throws IOException {
+    // The captured frame carries availableMargin, which the DTO does not declare.
+    // An exchange may add fields without notice, so an undeclared one must not fail
+    // the frame.
+    assertThat(futures("walletBalance.change.json").getCurrency()).isEqualTo(Currency.USDT);
+  }
+
+  @Test
+  void adaptsFuturesWalletFrameToBalance() throws IOException {
+    Balance balance = KucoinStreamingAdapters.adaptBalance(futures("walletBalance.change.json"));
+
+    assertThat(balance.getCurrency()).isEqualTo(Currency.USDT);
+    assertThat(balance.getTotal()).isEqualByComparingTo("50");
+    assertThat(balance.getAvailable()).isEqualByComparingTo("50");
+    assertThat(balance.getFrozen()).isEqualByComparingTo("0");
+  }
+
+  @Test
+  void adaptsFuturesWalletBalanceRatherThanEquity() throws IOException {
+    // Equity includes unrealised profit on open positions, so it moves with the
+    // market while no funds are transferred. The wallet balance is the deposited
+    // amount, which is what a Balance total means.
+    KucoinWsFuturesBalanceData data = futures("walletBalance.change.with-open-position.json");
+    Balance balance = KucoinStreamingAdapters.adaptBalance(data);
+
+    assertThat(data.getEquity()).isEqualByComparingTo("57.25");
+    assertThat(balance.getTotal()).isEqualByComparingTo("50");
+    assertThat(balance.getAvailable()).isEqualByComparingTo("42.75");
+    assertThat(balance.getFrozen()).isEqualByComparingTo("7.25");
+  }
+
+  @Test
+  void adaptsNullDataToNull() {
+    assertThat(KucoinStreamingAdapters.adaptBalance((KucoinWsSpotBalanceData) null)).isNull();
+    assertThat(KucoinStreamingAdapters.adaptBalance((KucoinWsFuturesBalanceData) null)).isNull();
+  }
+}

--- a/xchange-stream-kucoin/src/test/resources/account.balance.json
+++ b/xchange-stream-kucoin/src/test/resources/account.balance.json
@@ -1,0 +1,21 @@
+{
+  "channelType": "private",
+  "data": {
+    "accountId": "180131510502404",
+    "available": "0",
+    "availableChange": "-50",
+    "currency": "USDT",
+    "hold": "0",
+    "holdChange": "0",
+    "relationContext": {},
+    "relationEvent": "trade.setted",
+    "relationEventId": "6a8ef86ba9b2d300073d5397",
+    "time": "1787754603618",
+    "total": "0"
+  },
+  "id": "6a8ef86ba9b2d300073d5397",
+  "subject": "account.balance",
+  "topic": "/account/balance",
+  "type": "message",
+  "userId": "6a745823608d400001570a53"
+}

--- a/xchange-stream-kucoin/src/test/resources/account.balance.no-timestamp.json
+++ b/xchange-stream-kucoin/src/test/resources/account.balance.no-timestamp.json
@@ -1,0 +1,20 @@
+{
+  "channelType": "private",
+  "data": {
+    "accountId": "180131510502404",
+    "available": "0",
+    "availableChange": "-50",
+    "currency": "USDT",
+    "hold": "0",
+    "holdChange": "0",
+    "relationContext": {},
+    "relationEvent": "trade.setted",
+    "relationEventId": "6a8ef86ba9b2d300073d5397",
+    "total": "0"
+  },
+  "id": "6a8ef86ba9b2d300073d5397",
+  "subject": "account.balance",
+  "topic": "/account/balance",
+  "type": "message",
+  "userId": "6a745823608d400001570a53"
+}

--- a/xchange-stream-kucoin/src/test/resources/walletBalance.change.json
+++ b/xchange-stream-kucoin/src/test/resources/walletBalance.change.json
@@ -1,0 +1,27 @@
+{
+  "channelType": "private",
+  "data": {
+    "availableBalance": "50",
+    "availableMargin": "50",
+    "crossOrderMargin": "0",
+    "crossPosMargin": "0",
+    "crossUnPnl": "0",
+    "currency": "USDT",
+    "equity": "50",
+    "holdBalance": "0",
+    "isolatedFundingFeeMargin": "0",
+    "isolatedOrderMargin": "0",
+    "isolatedPosMargin": "0",
+    "isolatedUnPnl": "0",
+    "maxWithdrawAmount": "50",
+    "timestamp": "1787754633355",
+    "totalCrossMargin": "50",
+    "version": "18",
+    "walletBalance": "50"
+  },
+  "id": "6a8ef889c8c65100012e6701",
+  "subject": "walletBalance.change",
+  "topic": "/contractAccount/wallet",
+  "type": "message",
+  "userId": "6a745823608d400001570a53"
+}

--- a/xchange-stream-kucoin/src/test/resources/walletBalance.change.with-open-position.json
+++ b/xchange-stream-kucoin/src/test/resources/walletBalance.change.with-open-position.json
@@ -1,0 +1,27 @@
+{
+  "channelType": "private",
+  "data": {
+    "availableBalance": "42.75",
+    "availableMargin": "42.75",
+    "crossOrderMargin": "0",
+    "crossPosMargin": "7.25",
+    "crossUnPnl": "7.25",
+    "currency": "USDT",
+    "equity": "57.25",
+    "holdBalance": "7.25",
+    "isolatedFundingFeeMargin": "0",
+    "isolatedOrderMargin": "0",
+    "isolatedPosMargin": "0",
+    "isolatedUnPnl": "0",
+    "maxWithdrawAmount": "42.75",
+    "timestamp": "1787754633355",
+    "totalCrossMargin": "57.25",
+    "version": "19",
+    "walletBalance": "50"
+  },
+  "id": "6a8ef889c8c65100012e6702",
+  "subject": "walletBalance.change",
+  "topic": "/contractAccount/wallet",
+  "type": "message",
+  "userId": "6a745823608d400001570a53"
+}


### PR DESCRIPTION
Written to be upstreamable to `knowm/XChange` as-is: no references to any downstream consumer, and it
follows the wiki's [Code Style](https://github.com/knowm/XChange/wiki/Code-Style) and
[New Implementation Best Practices](https://github.com/knowm/XChange/wiki/New-Implementation-Best-Practices).

## Why

Two gaps stop a caller reading KuCoin balances at all.

**The private balance channels are adapted only to `FundingRecord`,** for funding-history callers. That
flattens each frame to its delta and keeps one figure:

- the spot adapter keeps `available`, dropping the total, the held amount, and **`relationEvent`** — the
  field identifying *which account* the change occurred in. The channel covers every account type of the
  logged-in user, and one currency exists in main, trade, margin and isolated at once, so a frame
  stripped of that field cannot be attributed to an account.
- the futures adapter likewise keeps `availableBalance` alone, dropping the wallet balance, held amount,
  equity, the margin breakdown, and **`version`** — which the exchange increments on every change and is
  the only way to detect a frame that never arrived.

**There is no way to read the futures wallet over REST.** The account API knows only the spot endpoints.
That matters because the websocket channel emits only on change: without a snapshot a caller has no
starting balance, and no way to re-synchronise after a reconnection.

## What this adds

Existing methods untouched — they have their own callers and their own purpose.

| | |
|---|---|
| `getBalanceChanges(Currency)` | spot, as total / available / held |
| `getFuturesBalanceChanges(Currency)` | futures, wallet balance as the total |
| `getRawSpotBalanceChanges()` | whole frame, for `relationEvent` |
| `getRawFuturesWalletChanges()` | whole frame, for `version` and the margin breakdown |
| `getKucoinFuturesAccountOverview(currency)` | `/api/v1/account-overview`, with the same retry and rate-limiter treatment as the other private calls |

The futures adapter takes `walletBalance` as the total, **not `equity`** — equity includes unrealised
profit and loss on open positions, so it varies with the market while no funds are transferred. There
is a test on a frame where the two differ.

## One correspondence left documented rather than guessed

The REST response and the websocket channel name the same quantities differently: `marginBalance` /
`frozenFunds` / `accountEquity` against `walletBalance` / `holdBalance` / `equity`.

Which REST field equals the channel's wallet balance is **not** established here. On an account with no
open position, `accountEquity`, `availableBalance`, `availableMargin`, `marginBalance` and
`maxWithdrawAmount` all carry the same value, so no such reading can distinguish them — confirming it
needs an account with an open position, where unrealised profit and committed margin are non-zero. The
field carries that caveat in its javadoc instead of a confident mapping.

## Tests — the module's first

`xchange-stream-kucoin` had none, so it gains a `junit-jupiter-engine` test dependency (assertj comes
from the parent's shared set).

Fixtures under `test/resources` are **real exchange responses**, captured by holding both authenticated
sockets open while funds were moved between a spot account and its futures wallet. Only
`walletBalance.change.with-open-position.json` is constructed, and only because the captured frame came
from an account with no open position, where wallet balance and equity are necessarily equal and so
cannot demonstrate which of the two an adapter reads.

Eleven tests: unmarshalling of both frames; amounts that arrive as JSON strings read as exact decimals;
`relationEvent`; an emptied account preserved as zero rather than null; an absent timestamp costing only
the timestamp rather than failing the frame; an undeclared field (`availableMargin`, which the DTO does
not declare) ignored rather than fatal; and wallet balance over equity.

The tests use the mapper the streaming services use rather than a fresh one — it is configured for
tolerant unknown properties and exact decimals, and a test on a differently configured mapper would
exercise behaviour the production path never sees.

## Conformance notes

- **Raw/adapted split respected:** the new REST call returns the exchange DTO and lives in
  `KucoinAccountServiceRaw`.
- **`google-java-format`:** every added line is within 100 columns, no tabs, no trailing whitespace.
  Pre-existing over-long lines in the touched files are deliberately left alone rather than reformatted,
  to keep the diff reviewable. A definitive `mvn com.spotify.fmt:fmt-maven-plugin:format` pass has
  **not** been run — no Maven on the machine this was written on — so that is worth a run before
  upstreaming.
- **No `new Date()` in DTOs:** timestamps come from the exchange's own field, and an absent one yields a
  null timestamp rather than "now".
- **Source level is Java 11 here**, so no text blocks; the fixtures live in `test/resources` rather than
  inline, which is the convention anyway.

## Verification

Compiled and run against the fork's own `6.1.0-SNAPSHOT` artifacts: main sources compile clean, test
compiles clean, **11/11 tests pass**. Done with `javac` and the JUnit platform launcher directly, since
Maven was unavailable — so the Maven build itself (and the formatter check) has not been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
