### PR TITLE
ci: re-push publish-snapshot.yml so the workflows API registers it

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -80,3 +80,5 @@ jobs:
           fi
           mvn clean deploy --no-transfer-progress --batch-mode \
             --settings /tmp/publish-settings.xml -Dfmt.skip=true $ARGS
+
+# (registration nudge: file re-pushed so the workflows API indexes it)


### PR DESCRIPTION
GitHub has not indexed the workflow added in #23 (~15 min on; `actions/workflows` still lists 2, dispatch 404s). A change to the file's path on the default branch re-fires registration. Comment-only change.